### PR TITLE
OCaml 4.01 compatibility

### DIFF
--- a/opam
+++ b/opam
@@ -21,6 +21,7 @@ depends: [
   "lwt"     {>= "2.4.3"}
   "ipaddr"  {>= "2.5.0"}
   "ctypes"  {>= "0.4.0"}
+  "ctypes-foreign"
   "extunix"
   "menhir"
 ]

--- a/parser.mly
+++ b/parser.mly
@@ -59,7 +59,7 @@ main:
       | _ -> choke "Only dhcp options are allowed in the global section")
       statements
   in
-  Config.{ subnets; options }
+  { Config.subnets; options }
 }
 
 ips:
@@ -107,7 +107,7 @@ subnet:
       | _ -> None)
       statements
   in
-  Config.{ network; range; options; hosts }
+  { Config.network; range; options; hosts }
 }
 
 hosts:
@@ -136,5 +136,5 @@ host:
       | _ -> None)
       statements
   in
-  Config.{ hostname; options; fixed_addr; hw_addr }
+  { Config.hostname; options; fixed_addr; hw_addr }
 }

--- a/util.ml
+++ b/util.ml
@@ -28,9 +28,13 @@ let filter_map f l =
   List.fold_left (fun a v -> match f v with Some v' -> v'::a | None -> a) [] l
 
 let finalize f g =
-  match f () with x -> g ();
-    x | exception e -> g ();
-    raise e
+  try
+    let x = f () in
+    g ();
+    x
+  with exn ->
+    g ();
+    raise exn
 
 open Ctypes
 open Foreign


### PR DESCRIPTION
This adds OCaml 4.01.0 compatibility, at the cost of not being able to use the nice exception matching syntax in 4.02.  We do still support 4.01 in Mirage, so this would be helpful to maintain for a little while (and Travis CI assists in ensuring it works without having to manually test it all the time)